### PR TITLE
Define provider explicitely

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -18,6 +18,11 @@ provider "azurerm" {
   features {}
 }
 
+#random provider
+provider "random" {
+  version = "~> 3.0"
+}
+
 # Pseudorandom prefix
 resource "random_string" "suffix" {
   length  = 8


### PR DESCRIPTION
Random is hashicorp standardized provider so it will be downloaded automatically. For taxonomy/fulltext searching sake and from completionist point of view its nice to have all used providers definer in file